### PR TITLE
Show promote dialog only on valid move

### DIFF
--- a/dreamchess/src/dreamchess.c
+++ b/dreamchess/src/dreamchess.c
@@ -204,12 +204,19 @@ static result_t *result_new(int code, const char *reason) {
 	return result;
 }
 
+int last_move_is_valid(move_t *move) {
+	if (!move_is_valid(history->last->board, move)) {
+		DBG_WARN("Move is illegal");
+		return 0;
+	}
+	return 1;
+}
+
 static int do_move(move_t *move, int ui_update) {
 	char *move_s, *move_f, *move_san;
 	board_t new_board;
 
-	if (!move_is_valid(history->last->board, move)) {
-		DBG_WARN("Move is illegal");
+	if (!last_move_is_valid(move)) {
 		return 0;
 	}
 

--- a/dreamchess/src/dreamchess.h
+++ b/dreamchess/src/dreamchess.h
@@ -50,6 +50,7 @@ void game_make_move_str(char *move_str, int ui_update);
 int game_get_engine_error(void);
 void game_set_engine_error(int err);
 
+int last_move_is_valid(move_t *move);
 int set_resolution(int init);
 void toggle_fullscreen(void);
 

--- a/dreamchess/src/gui/ui_sdlgl.c
+++ b/dreamchess/src/gui/ui_sdlgl.c
@@ -751,15 +751,16 @@ static void poll_move(void) {
 		return;
 	}
 
-	if ((needprom == 0) && (((board.square[source] == WHITE_PAWN) && (dest >= 56)) ||
-							((board.square[source] == BLACK_PAWN) && (dest <= 7)))) {
+	move.source = source;
+	move.destination = dest;
+	move.promotion_piece = QUEEN;
+	if ((last_move_is_valid(&move) == 1) && (needprom == 0) &&
+			(((board.square[source] == WHITE_PAWN) && (dest >= 56)) ||
+			 ((board.square[source] == BLACK_PAWN) && (dest <= 7)))) {
 		gg_dialog_open(dialog_promote_create(COLOUR(board.square[source])));
 		needprom = 1;
 		return;
 	}
-
-	move.source = source;
-	move.destination = dest;
 	if (needprom == 2)
 		move.promotion_piece = dialog_promote_piece;
 	else


### PR DESCRIPTION
Hi, thanks for this great game and not talking about chess haha, hope its a correct patch happy to fixup or give more info, cheers

With a game with black king on B8 and white pawn on B7. When selecting
white pawn to go over the king I could have the promote dialog, after
selecting queen for example the game go back to the original state.

This patch check that the move is valid first before showing the promote
dialog.